### PR TITLE
proper acknowledgement, quoting, removed player() debug

### DIFF
--- a/spotify-adkiller.sh
+++ b/spotify-adkiller.sh
@@ -139,11 +139,12 @@ get_pactl_nr(){
             $1 == "index:" {idx = $2} 
             $1 == "application.process.binary" && $3 == "\"" binary "\"" {print idx; exit}
         '
-    # awk script by Glenn Jackmann (http://askubuntu.com/a/180661/81372)
+    # awk script by Glenn Jackmann (http://askubuntu.com/users/10127/)
+    # first posted on http://askubuntu.com/a/180661
 }
 
 player(){
-    RANDOMTRACK="$(find $LOCALMUSIC -name "*.mp3" | sort --random-sort | head -1)"
+    RANDOMTRACK="$(find "$LOCALMUSIC" -name "*.mp3" | sort --random-sort | head -1)"
     notify-send -i spotify "Spotify AdKiller" "Playing ${RANDOMTRACK##*/}"
     $PLAYER "$ALERT" > /dev/null 2>&1 &         # alert user of switch to local playback
     $PLAYER "$RANDOMTRACK" > /dev/null 2>&1 &   # play random track
@@ -236,7 +237,6 @@ while read -r XPROPOUTPUT; do
           ADMUTE=1
     fi
     print_horiz_line
-    player
 
 done < <(xprop -spy -name "$WMTITLE" WM_ICON_NAME)
 # use process substitution instead of piping to preserve variables


### PR DESCRIPTION
This commit fixes two nasty issues I forgot to fix before making the first pull request:
- I had forgotten to remove a debug call to player(), which caused the script to keep on switching to local playback
- I hadn't quoted LOCALMUSIC properly, which made the local playback fail if the user set a custom music path with spaces
