### PR TITLE
1.0.14 compatibility

### DIFF
--- a/dbusiface.py
+++ b/dbusiface.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import dbus
+import re
+import json
+
+def get_metadata():
+    session_bus = dbus.SessionBus()
+    proxy = session_bus.get_object("org.mpris.MediaPlayer2.spotify", "/org/mpris/MediaPlayer2")
+    properties = dbus.Interface(proxy, "org.freedesktop.DBus.Properties")
+    player = dbus.Interface(proxy, "org.mpris.MediaPlayer2.Player")
+    d = properties.Get("org.mpris.MediaPlayer2.Player", "Metadata")
+    return d
+
+if __name__=="__main__":
+    data = json.loads(json.dumps(get_metadata()))
+    print(", ".join(data["xesam:artist"]) + " - " + data["xesam:title"])


### PR DESCRIPTION
An easier way to detect ads would be to just grep for "spotify:ad" in the metadata, that can now be retrieved using `dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata'` but this is probably not possible with old versions. I did it this way cause it was the minimal amount of change needed to get it working with new versions. We also need to check if Spotify is paused, and I did not find any way of doing this over DBUS. One way would be to [check for corking](https://github.com/ysangkok/spotify-blacklist-mute/blob/master/spotifymute_helper.sh#L7), this would allow removing the xprop code, in theory. This is a larger change though.