### PR TITLE
Clarity of Intention

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ The default configuration file will be written automatically on the first startu
 
 ### Usage
 
-If you installed `Spotify-AdKiller` correctly, a new entry called `Spotify (AdKiller)` should appear in your menu. From now on please use this launcher to start Spotify. The script will terminate automatically as soon as Spotify exits.
+If you installed `Spotify-AdKiller` correctly, a new entry called `Spotify (AdKiller)` should appear in your menu. As mentioned before, **this is for testing purposes ONLY!** so it is advised that you use this new entry only when your purposes are **testing**.
+
+Use this entry for those *testing purposes* From now on please use this launcher to start Spotify. The script will terminate automatically as soon as Spotify exits.
 
 **Important note:** Please make sure you don't have notifications disabled in your Spotify configuration (`ui.track_notifications_enabled=true` in `~/.config/spotify/User/<your username>/prefs`).
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,7 @@ The default configuration file will be written automatically on the first startu
 
 ### Usage
 
-If you installed `Spotify-AdKiller` correctly, a new entry called `Spotify (AdKiller)` should appear in your menu. As mentioned before, **this is for testing purposes ONLY!** so it is advised that you use this new entry only when your purposes are **testing**.
-
-Use this entry for those *testing purposes* From now on please use this launcher to start Spotify. The script will terminate automatically as soon as Spotify exits.
+If you installed `Spotify-AdKiller` correctly, a new entry called `Spotify (AdKiller)` should appear in your menu. This launcher will start Spotify in ad-free mode. The script will terminate automatically as soon as Spotify exits. As mentioned before, **this is for testing purposes ONLY!** so it is advised that you use this new entry only when your purposes are **testing**.
 
 **Important note:** Please make sure you don't have notifications disabled in your Spotify configuration (`ui.track_notifications_enabled=true` in `~/.config/spotify/User/<your username>/prefs`).
 


### PR DESCRIPTION
"From now on..." implies that one will not use ad-supported Spotify anymore, which contradicts the declared intentions of this ad blocker. Certainly this slip-up does not reflect a deceptive declaration of intention. More likely, the wording "From now on..." was meant to apply to the scope of a party, meaning, "From now until the end of the party you are currently throwing." This pull request clarifies the author's declared intention of supplying this software in the good faith that nobody is going to use it to the exclusion of enjoying Spotify's excellent advertisements.

Sincerely, an open-source volunteer armchair lawyer.*

* No implication of legal degree intended