### PR TITLE
Show path in local-track notification

### DIFF
--- a/spotify-adkiller.sh
+++ b/spotify-adkiller.sh
@@ -367,7 +367,7 @@ spotify_dbus(){
 
 player(){
     RANDOM_TRACK="$(find "$LOCAL_MUSIC" -iname "*.mp3" | sort --random-sort | head -1)"
-    notify_send "Playing ${RANDOM_TRACK##*/}"
+    notify_send "Playing ${RANDOM_TRACK##$LOCAL_MUSIC/}"
     $PLAYER $1 "$RANDOM_TRACK" > /dev/null 2>&1 &             # Play random track
     PLAYER_PID="$!"                                           # Get PLAYER PID
     echo "$PLAYER_PID" > "$PIDFILE"                           # Store player PID


### PR DESCRIPTION
I think it's way more informative to show the full path (starting at the LOCAL_MUSIC-dir) in the notification for local tracks.
That's because I think for most people the folders contain information about the album, artist and stuff.