### PR TITLE
fix Spotify sink not being unmuted when exiting AdKiller

### DIFF
--- a/spotify-adkiller.sh
+++ b/spotify-adkiller.sh
@@ -611,6 +611,8 @@ restore_settings(){
     # `pactl` can only control active sinks, i.e. if Spotify isn't running we can't
     # control its mute state. So we have to resort to unmuting Spotify on every initial
     # run of this script (INITIALRUN=1)
+    # However, we can always unmute the Spotify sink if it is running.
+    if pgrep spotify &>/dev/null; then unmute; fi
 }
 
 ## PREPARATION


### PR DESCRIPTION
Imho, the Spotify sink should be unmuted when AdKiller is exited,
returning control over mute state to the user. Otherwise, the user is
forced to maually unmute the Spotify sink if he wants to keep on
listening.