### PR TITLE
Add more URLs to blacklist

### DIFF
--- a/experimental/dns-block.c
+++ b/experimental/dns-block.c
@@ -13,13 +13,13 @@
 #include <fnmatch.h>
 
 #define WHITELIST_LENGTH   5
-#define BLACKLIST_LENGTH   1
+#define BLACKLIST_LENGTH   3
 
 const char *hostname_whitelist[WHITELIST_LENGTH] =
     { "*.spotify.com", "*.cloudfront.net", "api.tunigo.com", "apic.musixmatch.com", "mxmscripts.s3.amazonaws.com" };
     
 const char *hostname_blacklist[BLACKLIST_LENGTH] =
-    { "adeventtracker.spotify.com" };
+    { "adeventtracker.spotify.com", "audio-sp-ash.spotify.com", "spclient.wg.spotify.com" };
  
 int getaddrinfo(const char *hostname, const char *service,
                 const struct addrinfo *hints, struct addrinfo **res)


### PR DESCRIPTION
Regarding issue #65 adding those two URLs seems to stop the ads, for now. 

I noticed that before and ad a call to `spclient.wg.spotify.com` was issued and the ad brought by `audio-sp-ash.spotify.com`. 

The modifications doesn't seem to interfere with the already functioning features from `dns-block`. That means: lyrics not working, cover art not downloading in some cases, etc...