### PR TITLE
Parallel original spotify.desktop to enable device scaling

### DIFF
--- a/Spotify (AdKiller).desktop
+++ b/Spotify (AdKiller).desktop
@@ -4,6 +4,7 @@ GenericName=Music Player
 Comment=Your Music - without ads!
 Icon=spotify-client
 Exec=spotify-wrapper.sh %U
+# for DPI scaling: Exec=spotify-wrapper.sh --force-device-scale-factor=1.5 %U
 TryExec=spotify
 Terminal=false
 Type=Application

--- a/spotify-wrapper.sh
+++ b/spotify-wrapper.sh
@@ -154,5 +154,5 @@ adkiller_launch(){
 ## MAIN
 
 read_write_config
-spotify_launch
+spotify_launch "$@"
 adkiller_launch


### PR DESCRIPTION
My original spotify.desktop looked like this:
```
[Desktop Entry]
Name=Spotify
GenericName=Music Player
Comment=Spotify streaming music client
Icon=spotify-client
Exec=spotify --force-device-scale-factor=1.000001 %U
TryExec=spotify
Terminal=false
Type=Application
Categories=Audio;Music;Player;AudioVideo;
MimeType=x-scheme-handler/spotify;
```

However, appending `--force-device-scale-factor` to `Exec=spotify-wrapper.sh` did not have any effect.  This change fixes that and also documents how to change the display scaling, which is necessary on high DPI displays.