### PR TITLE
Update Arch Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Install all utilities + VLC on **[Ubuntu](http://www.ubuntu.com/)** with:
 
 [![Arch Linux](http://www.faderweb.de/img/archlinux.jpg)](http://www.archlinux.org/)
 
-There is an [AUR Package](https://aur.archlinux.org/packages/spotify-adkiller/) for  **[Arch Linux](http://www.archlinux.org/)**. To install:
+There is an [AUR Package](https://aur.archlinux.org/packages/spotify-adkiller-git/) for  **[Arch Linux](http://www.archlinux.org/)**. To install:
 
-    git clone https://aur.archlinux.org/spotify-adkiller.git
-    cd spotify-adkiller
-    makepkg -i
+    git clone https://aur.archlinux.org/spotify-adkiller-git.git
+    cd spotify-adkiller-git
+    makepkg -si
 
 ### Installation
 


### PR DESCRIPTION
- Packages following the Git HEAD have -git appended to them.
  https://wiki.archlinux.org/index.php/VCS_package_guidelines
- `makepkg -s` installs missing dependencies

The spotify-adkiller package is still available, but will be merged soon.