### PR TITLE
Add u.scdn.co to the dns-block whitelist

### DIFF
--- a/experimental/dns-block.c
+++ b/experimental/dns-block.c
@@ -12,12 +12,12 @@
 
 #include <fnmatch.h>
 
-#define WHITELIST_LENGTH   8
+#define WHITELIST_LENGTH   9
 #define BLACKLIST_LENGTH   3
 
 const char *hostname_whitelist[WHITELIST_LENGTH] =
     { "*.spotify.com", "*.cloudfront.net", "api.tunigo.com", "apic.musixmatch.com",
-      "mxmscripts.s3.amazonaws.com", "artistheader.scdn.co", "profile-images.scdn.co", "i.scdn.co" };
+      "mxmscripts.s3.amazonaws.com", "artistheader.scdn.co", "profile-images.scdn.co", "i.scdn.co", "u.scdn.co" };
     
 const char *hostname_blacklist[BLACKLIST_LENGTH] =
     { "adeventtracker.spotify.com", "audio-sp-ash.spotify.com", "spclient.wg.spotify.com" };


### PR DESCRIPTION
Blocking u.scdn.co leads to missing playlist covers.