### PR TITLE
Added code that creates $APPDIR if it doesn't exist.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,6 +115,11 @@ if [[ ! -f "$SCRIPT" || ! -f "$WRAPPER" || ! -f "$CONFIGFILE" ]]; then
   exit 1
 fi
 
+## if $APPDIR is missing then create it
+if [[ ! -d "$APPDIR" ]]; then
+ mkdir -vp "$APPDIR"
+fi
+
 echo
 
 echo "## Changing permissions ##"

--- a/install.sh
+++ b/install.sh
@@ -115,11 +115,6 @@ if [[ ! -f "$SCRIPT" || ! -f "$WRAPPER" || ! -f "$CONFIGFILE" ]]; then
   exit 1
 fi
 
-## if $APPDIR is missing then create it
-if [[ ! -d "$APPDIR" ]]; then
- mkdir -vp "$APPDIR"
-fi
-
 echo
 
 echo "## Changing permissions ##"
@@ -131,6 +126,7 @@ echo
 echo "## Creating installation directories ##"
 mkdir -vp "$INSTALLDIR"
 mkdir -vp "$CONFIGDIR"
+mkdir -vp "$APPDIR"
 
 echo
 


### PR DESCRIPTION
On my fresh install of Xubuntu the directory 'applications' in $HOME/.local/share did not exist which caused install.sh to fail with it's copy of "Spotify (AdKiller).desktop" to that dir. I solved this by creating the missing folder and running install.sh oncemore.

I've added code to install.sh that resolves this issue from happening in the future.

