### PR TITLE
Update .cfg file comment to match README

### DIFF
--- a/Spotify-AdKiller.cfg
+++ b/Spotify-AdKiller.cfg
@@ -8,7 +8,7 @@ CUSTOM_MODE=""
 # - simple        — mute Spotify, unmute when ad is over
 # - interstitial  — mute Spotify, play random local track, stop and unmute when ad is over
 # - continuous    — mute Spotify, play random local track, stop and unmute when track is over
-# -> set to simple by default
+# -> set to continuous by default
 
 CUSTOM_PLAYER=""
 CUSTOM_LOOPOPT=""


### PR DESCRIPTION
In reference to `CUSTOM_MODE`, `README.md` says that

> The default ad blocking mode is `continuous`.

but `Spotify-AdKiller.cfg` says that `CUSTOM_MODE` is

> ```ini
> # -> set to simple by default
> ```

I seem to get different behavior when I set `CUSTOM_MODE="simple"` in comparison to when I leave it as `CUSTOM_MODE=""`, so I'm guessing that the README is correct here.