### PR TITLE
Inhibit PowerManagement while playing music

### DIFF
--- a/Spotify-AdKiller.cfg
+++ b/Spotify-AdKiller.cfg
@@ -25,6 +25,11 @@ CUSTOM_MUSIC=""
 # local music directory / track
 # -> set to XDG standard music directory by default
 
+INHIBIT_POWERMANAGEMENT="1"
+# Prevent Shutdown/Suspend while playing music
+# - "1" to enable
+# - "0" to disable
+
 DEBUG="0"
 # control debug mode
 # - "1" to enable


### PR DESCRIPTION
Since this script is already running in parallel with Spotify I think it is a neat little addition to make the script inhibit suspend while Spotify is playing music.

As far as I know Spotify does this already on GNOME. This PR should add the feature for all FreeDesktop-compliant desktop environments (But I only tested it on KDE 5).