### PR TITLE
Added a line to make the .desktop file executable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,7 @@ cp -v "$SCRIPT" "$INSTALLDIR/"
 cp -v "$WRAPPER" "$INSTALLDIR/"
 [[ ! -f "$CONFIGDIR/$CONFIGFILE" ]] && cp -v "$CONFIGFILE" "$CONFIGDIR/"
 cp -v "$DESKTOPFILE" "$APPDIR/"
+chmod +x "$APPDIR/$DESKTOPFILE"
 
 echo
 


### PR DESCRIPTION
On Ubuntu 17.04 (Gnome 3.24.2) (And presumably on other versions) the .desktop file isn't made executable.
This occurred on a used system so its not impossible it was some random glitch, but if it isn't the (trivial) fix is here.