### PR TITLE
Make sure to mute all sinks as Spotify spawn multiple sound processes

### DIFF
--- a/spotify-adkiller.sh
+++ b/spotify-adkiller.sh
@@ -246,7 +246,7 @@ get_state(){
 get_pactl_nr(){
     LC_ALL=C pacmd list-sink-inputs | awk -v binary="$BINARY" '
             $1 == "index:" {idx = $2}
-            $1 == "application.process.binary" && $3 == "\"" binary "\"" {print idx; exit}
+            $1 == "application.process.binary" && $3 == "\"" binary "\"" {print idx}
         '
     # awk script by Glenn Jackmann (http://askubuntu.com/users/10127/)
     # first posted on http://askubuntu.com/a/180661


### PR DESCRIPTION
Currently `get_pactl_nr()` only returns the first matching index, but it Spotify tends to create new playback streams, letting previous ones idling. So the first stream is mute, while the ad is actually playing in the latest one.

This change make sure that all Spotify streams are (un)muted.

Example after ~15min:

![](http://i.imgur.com/drBO2vT.png)

(This one with the proper git branch)